### PR TITLE
Revert cast of `defaultdict` to `dict` before return

### DIFF
--- a/brainglobe_utils/cells/cells.py
+++ b/brainglobe_utils/cells/cells.py
@@ -356,19 +356,18 @@ def transform_cell_positions(
     return transformed_cells_no_none
 
 
-def group_cells_by_z(cells: List[Cell]) -> Dict[float, List[Cell]]:
+def group_cells_by_z(cells: List[Cell]) -> defaultdict[float, List[Cell]]:
     """
     For a list of Cells return a dict of lists of cells, grouped by plane.
 
     :param list cells: list of cells from cellfinder.cells.cells.Cell
-    :return:  default
-    dict, with each key being a plane (e.g. 1280) and each entry being a list
+    :return:  defaultdict, with each key being a plane (e.g. 1280) and each entry being a list
     of Cells
     """
     cells_groups = defaultdict(list)
     for cell in cells:
         cells_groups[cell.z].append(cell)
-    return dict(cells_groups)
+    return cells_groups
 
 
 class MissingCellsError(Exception):


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`defaultdict` and `dict` behave slightly differently when new keys are created implicitly. Casting to a `dict` appears to disregard this behaviour, which is implicitly assumed in `cellfinder`'s units.

**What does this PR do?**

Reverts the output of `cells.cells.group_cells_by_z` to be a `defaultdict` rather than a `dict`.

## References

- This will close [cellfinder#235](https://github.com/brainglobe/cellfinder/issues/235)

## How has this PR been tested?

See the debug branch https://github.com/brainglobe/cellfinder/pull/236.

According to the docs, `defaultdict` is a subclass of `dict` too so there is no reason for us to "cast" and loose the functionality of the subclass. If we really need to do this, it is better to set the `default_factory` member to be `None` rather than perform an explicit cast.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Nope.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
