### PR TITLE
Add slurmio back to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PyYAML",
     "scipy",
     "numpy",
+    "slurmio"
 ]
 
 license = {text = "MIT"}
@@ -56,14 +57,9 @@ dev = [
   "setuptools_scm",
   "pyqt5",
   "superqt",
-  "slurmio",
   "scikit-image"
 ]
 
-# For use with the SLURM job scheduler
-slurmio = [
-  "slurmio",
-]
 
 [build-system]
 requires = [


### PR DESCRIPTION
I decided to put slurmio back into the "normal" dependencies for a few reasons:
- It broke some things (e.g. https://github.com/brainglobe/brainglobe-napari-io/pull/56)
- It's likely to break some more things
- It's not a problematic dependency (pure python and we maintain it)
- Chances are we want it to be available in many BG tools. 