### PR TITLE
Convert image_io docstrings to numpydoc style

### DIFF
--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -44,31 +44,36 @@ def load_any(
     Parameters
     ----------
     src_path : str
-        Can be the path of a nifty file, tiff file, tiff files folder, or text file
-        containing a list of paths.
+        Can be the path of a nifty file, tiff file, tiff files folder, or text
+        file containing a list of paths.
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     z_scaling_factor : float
-        The scaling of the brain along the z dimension (applied on loading before return).
+        The scaling of the brain along the z dimension (applied on loading
+        before return).
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     load_parallel : bool
         Load planes in parallel using multiprocessing for faster data loading.
 
     sort_input_file : bool
-        If set to true and the input is a filepaths file, it will be naturally sorted.
+        If set to true and the input is a filepaths file, it will be naturally
+        sorted.
 
     as_numpy : bool
-        Whether to convert the image to a numpy array in memory (rather than a memmap).
-        Only relevant for .nii files.
+        Whether to convert the image to a numpy array in memory (rather than a
+        memmap). Only relevant for .nii files.
 
     verbose : bool
         Print more information about the process.
@@ -165,17 +170,21 @@ def load_img_stack(
         The path of the image to be loaded.
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     z_scaling_factor : float
-        The scaling of the brain along the z dimension (applied on loading before return).
+        The scaling of the brain along the z dimension (applied on loading
+        before return).
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     Returns
     -------
@@ -224,10 +233,12 @@ def load_nii(src_path, as_array=False, as_numpy=False):
         The path to the nifty file on the filesystem.
 
     as_array : bool
-        Whether to convert the brain to a numpy array or keep it as a nifty object.
+        Whether to convert the brain to a numpy array or keep it as a nifty
+        object.
 
     as_numpy : bool
-        Whether to convert the image to a numpy array in memory (rather than a memmap).
+        Whether to convert the image to a numpy array in memory (rather than a
+        memmap).
 
     Returns
     -------
@@ -258,9 +269,9 @@ def load_from_folder(
 ):
     """
     Load a brain from a folder. All tiff files will be read sorted and assumed
-    to belong to the same sample. Optionally, a name_filter string can be supplied
-    which will have to be present in the file names for them to be considered part
-    of the sample.
+    to belong to the same sample. Optionally, a name_filter string can be
+    supplied which will have to be present in the file names for them to be
+    considered part of the sample.
 
     Parameters
     ----------
@@ -268,20 +279,24 @@ def load_from_folder(
         The source folder containing tiff files.
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     z_scaling_factor : float
         The scaling of the brain along the z dimension.
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     file_extension : str
-        Will have to be present in the file names for them to be considered part of the sample.
+        Will have to be present in the file names for them to be considered
+        part of the sample.
 
     load_parallel : bool
         Use multiprocessing to speed up image loading.
@@ -324,26 +339,31 @@ def load_img_sequence(
     Parameters
     ----------
     img_sequence_file_path : str
-        The path to the file containing the ordered list of image paths (one per line).
+        The path to the file containing the ordered list of image paths (one
+        per line).
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     z_scaling_factor : float
         The scaling of the brain along the z dimension.
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     load_parallel : bool
         Use multiprocessing to speed up image loading.
 
     sort : bool
-        If set to true, will perform a natural sort of the file paths in the list.
+        If set to true, will perform a natural sort of the file paths in the
+        list.
 
     n_free_cpus : int
         Number of CPU cores to leave free.
@@ -390,17 +410,20 @@ def load_image_series(
         Ordered list of image paths.
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     z_scaling_factor : float
         The scaling of the brain along the z dimension.
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     load_parallel : bool
         Use multiprocessing to speed up image loading.
@@ -452,14 +475,17 @@ def threaded_load_from_sequence(
         The sorted list of the planes paths on the filesystem.
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     n_free_cpus : int
         Number of CPU cores to leave free.
@@ -518,14 +544,17 @@ def load_from_paths_sequence(
         The sorted list of the planes paths on the filesystem.
 
     x_scaling_factor : float
-        The scaling of the brain along the x dimension (applied on loading before return).
+        The scaling of the brain along the x dimension (applied on loading
+        before return).
 
     y_scaling_factor : float
-        The scaling of the brain along the y dimension (applied on loading before return).
+        The scaling of the brain along the y dimension (applied on loading
+        before return).
 
     anti_aliasing : bool
-        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
-        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+        Whether to apply a Gaussian filter to smooth the image prior to
+        down-scaling. It is crucial to filter when down-sampling the image to
+        avoid aliasing artifacts.
 
     Returns
     -------

--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -41,27 +41,45 @@ def load_any(
     .. warning:: x and y scaling not used at the moment if loading a
         complete image
 
-    :param str src_path: Can be the path of a nifty file, tiff file,
-        tiff files folder or text file containing a list of paths
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param float z_scaling_factor: The scaling of the brain along the z
-        dimension (applied on loading before return)
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :param bool load_parallel: Load planes in parallel using multiprocessing
-        for faster data loading
-    :param bool sort_input_file: If set to true and the input is a filepaths
-        file, it will be naturally sorted
-    :param bool as_numpy: Whether to convert the image to a numpy array in
-        memory (rather than a memmap). Only relevant for .nii files.
-    :param bool verbose: Print more information about the process
-    :param int n_free_cpus: Number of cpu cores to leave free.
-    :return: The loaded brain
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    src_path : str
+        Can be the path of a nifty file, tiff file, tiff files folder, or text file
+        containing a list of paths.
+
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    z_scaling_factor : float
+        The scaling of the brain along the z dimension (applied on loading before return).
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    load_parallel : bool
+        Load planes in parallel using multiprocessing for faster data loading.
+
+    sort_input_file : bool
+        If set to true and the input is a filepaths file, it will be naturally sorted.
+
+    as_numpy : bool
+        Whether to convert the image to a numpy array in memory (rather than a memmap).
+        Only relevant for .nii files.
+
+    verbose : bool
+        Print more information about the process.
+
+    n_free_cpus : int
+        Number of CPU cores to leave free.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded brain.
     """
     src_path = str(src_path)
 
@@ -114,11 +132,17 @@ def load_any(
 
 def load_nrrd(src_path):
     """
-    Load an .nrrd file as a numpy array
+    Load an .nrrd file as a numpy array.
 
-    :param str src_path: The path of the image to be loaded
-    :return: The loaded brain array
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    src_path : str
+        The path of the image to be loaded.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded brain array.
     """
     src_path = str(src_path)
     stack, _ = nrrd.read(src_path)
@@ -133,20 +157,30 @@ def load_img_stack(
     anti_aliasing=True,
 ):
     """
-    Load a tiff stack as a numpy array
+    Load a tiff stack as a numpy array.
 
-    :param str stack_path: The path of the image to be loaded
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param float z_scaling_factor: The scaling of the brain along the z
-        dimension (applied on loading before return)
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :return: The loaded brain array
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    stack_path : str
+        The path of the image to be loaded.
+
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    z_scaling_factor : float
+        The scaling of the brain along the z dimension (applied on loading before return).
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded brain array.
     """
     stack_path = str(stack_path)
     logging.debug(f"Loading: {stack_path}")
@@ -182,14 +216,23 @@ def load_img_stack(
 
 def load_nii(src_path, as_array=False, as_numpy=False):
     """
-    Load a brain from a nifti file
+    Load a brain from a nifti file.
 
-    :param str src_path: The path to the nifty file on the filesystem
-    :param bool as_array: Whether to convert the brain to a numpy array of
-        keep it as nifty object
-    :param bool as_numpy: Whether to convert the image to a numpy array in
-        memory (rather than a memmap)
-    :return: The loaded brain (format depends on the above flag)
+    Parameters
+    ----------
+    src_path : str
+        The path to the nifty file on the filesystem.
+
+    as_array : bool
+        Whether to convert the brain to a numpy array or keep it as a nifty object.
+
+    as_numpy : bool
+        Whether to convert the image to a numpy array in memory (rather than a memmap).
+
+    Returns
+    -------
+    np.ndarray or nifty object
+        The loaded brain. The format depends on the `as_array` flag.
     """
     src_path = str(src_path)
     nii_img = nib.load(src_path)
@@ -215,27 +258,41 @@ def load_from_folder(
 ):
     """
     Load a brain from a folder. All tiff files will be read sorted and assumed
-    to belong to the same sample.
-    Optionally a name_filter string can be supplied which will have to be
-    present in the file names for them
-    to be considered part of the sample
+    to belong to the same sample. Optionally, a name_filter string can be supplied
+    which will have to be present in the file names for them to be considered part
+    of the sample.
 
-    :param str src_folder:
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param float z_scaling_factor: The scaling of the brain along the z
-        dimension
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :param str file_extension: will have to be present in the file names for
-        them to be considered part of the sample
-    :param bool load_parallel: Use multiprocessing to speedup image loading
-    :param int n_free_cpus: Number of cpu cores to leave free.
-    :return: The loaded and scaled brain
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    src_folder : str
+        The source folder containing tiff files.
+
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    z_scaling_factor : float
+        The scaling of the brain along the z dimension.
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    file_extension : str
+        Will have to be present in the file names for them to be considered part of the sample.
+
+    load_parallel : bool
+        Use multiprocessing to speed up image loading.
+
+    n_free_cpus : int
+        Number of CPU cores to leave free.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded and scaled brain.
     """
     paths = get_sorted_file_paths(src_folder, file_extension=file_extension)
 
@@ -262,25 +319,39 @@ def load_img_sequence(
 ):
     """
     Load a brain from a sequence of files specified in a text file containing
-    an ordered list of paths
+    an ordered list of paths.
 
-    :param str img_sequence_file_path: The path to the file containing the
-        ordered list of image paths (one per line)
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param float z_scaling_factor: The scaling of the brain along the z
-        dimension
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :param bool load_parallel: Use multiprocessing to speedup image loading
-    :param bool sort: If set to true will perform a natural sort of the
-        file paths in the list
-    :param int n_free_cpus: Number of cpu cores to leave free.
-    :return: The loaded and scaled brain
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    img_sequence_file_path : str
+        The path to the file containing the ordered list of image paths (one per line).
+
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    z_scaling_factor : float
+        The scaling of the brain along the z dimension.
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    load_parallel : bool
+        Use multiprocessing to speed up image loading.
+
+    sort : bool
+        If set to true, will perform a natural sort of the file paths in the list.
+
+    n_free_cpus : int
+        Number of CPU cores to leave free.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded and scaled brain.
     """
     img_sequence_file_path = str(img_sequence_file_path)
     with open(img_sequence_file_path, "r") as in_file:
@@ -311,24 +382,37 @@ def load_image_series(
 ):
     """
     Load a brain from a sequence of files specified in a text file containing
-    an ordered list of paths
+    an ordered list of paths.
 
-    :param lost paths: Ordered list of image paths
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param float z_scaling_factor: The scaling of the brain along the z
-        dimension
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :param bool load_parallel: Use multiprocessing to speedup image loading
-    :param int n_free_cpus: Number of cpu cores to leave free.
-    :return: The loaded and scaled brain
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    paths : list
+        Ordered list of image paths.
+
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    z_scaling_factor : float
+        The scaling of the brain along the z dimension.
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    load_parallel : bool
+        Use multiprocessing to speed up image loading.
+
+    n_free_cpus : int
+        Number of CPU cores to leave free.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded and scaled brain.
     """
-
     if load_parallel:
         img = threaded_load_from_sequence(
             paths,
@@ -362,20 +446,29 @@ def threaded_load_from_sequence(
     """
     Use multiprocessing to load a brain from a sequence of image paths.
 
-    :param list paths_sequence: The sorted list of the planes paths on the
-        filesystem
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :param int n_free_cpus: Number of cpu cores to leave free.
-    :return: The loaded and scaled brain
-    :rtype: np.ndarray
-    """
+    Parameters
+    ----------
+    paths_sequence : list
+        The sorted list of the planes paths on the filesystem.
 
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    n_free_cpus : int
+        Number of CPU cores to leave free.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded and scaled brain.
+    """
     stacks = []
     n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
 
@@ -419,17 +512,25 @@ def load_from_paths_sequence(
     A single core version of the function to load a brain from a sequence of
     image paths.
 
-    :param list paths_sequence: The sorted list of the planes paths on the
-        filesystem
-    :param float x_scaling_factor: The scaling of the brain along the x
-        dimension (applied on loading before return)
-    :param float y_scaling_factor: The scaling of the brain along the y
-        dimension (applied on loading before return)
-    :param bool anti_aliasing: Whether to apply a Gaussian filter to smooth
-        the image prior to down-scaling. It is crucial to filter when
-        down-sampling the image to avoid aliasing artifacts.
-    :return: The loaded and scaled brain
-    :rtype: np.ndarray
+    Parameters
+    ----------
+    paths_sequence : list
+        The sorted list of the planes paths on the filesystem.
+
+    x_scaling_factor : float
+        The scaling of the brain along the x dimension (applied on loading before return).
+
+    y_scaling_factor : float
+        The scaling of the brain along the y dimension (applied on loading before return).
+
+    anti_aliasing : bool
+        Whether to apply a Gaussian filter to smooth the image prior to down-scaling.
+        It is crucial to filter when down-sampling the image to avoid aliasing artifacts.
+
+    Returns
+    -------
+    np.ndarray
+        The loaded and scaled brain.
     """
     for i, p in enumerate(
         tqdm(paths_sequence, desc="Loading images", unit="plane")
@@ -466,12 +567,20 @@ def load_from_paths_sequence(
 def get_size_image_from_file_paths(file_path, file_extension="tif"):
     """
     Returns the size of an image (which is a list of 2D files), without loading
-    the whole image
-    :param str file_path: File containing file_paths in a text file,
-    or as a list.
-    :param str file_extension: Optional file extension (if a directory
-     is passed)
-    :return: Dict of image sizes
+    the whole image.
+
+    Parameters
+    ----------
+    file_path : str
+        File containing file_paths in a text file, or as a list.
+
+    file_extension : str, optional
+        Optional file extension (if a directory is passed).
+
+    Returns
+    -------
+    dict
+        Dict of image sizes.
     """
     file_path = str(file_path)
 

--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -47,38 +47,38 @@ def load_any(
         Can be the path of a nifty file, tiff file, tiff files folder, or text
         file containing a list of paths.
 
-    x_scaling_factor : float
+    x_scaling_factor : float, optional
         The scaling of the brain along the x dimension (applied on loading
         before return).
 
-    y_scaling_factor : float
+    y_scaling_factor : float, optional
         The scaling of the brain along the y dimension (applied on loading
         before return).
 
-    z_scaling_factor : float
+    z_scaling_factor : float, optional
         The scaling of the brain along the z dimension (applied on loading
         before return).
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
 
-    load_parallel : bool
+    load_parallel : bool, optional
         Load planes in parallel using multiprocessing for faster data loading.
 
-    sort_input_file : bool
+    sort_input_file : bool, optional
         If set to true and the input is a filepaths file, it will be naturally
         sorted.
 
-    as_numpy : bool
+    as_numpy : bool, optional
         Whether to convert the image to a numpy array in memory (rather than a
         memmap). Only relevant for .nii files.
 
-    verbose : bool
+    verbose : bool, optional
         Print more information about the process.
 
-    n_free_cpus : int
+    n_free_cpus : int, optional
         Number of CPU cores to leave free.
 
     Returns
@@ -181,7 +181,7 @@ def load_img_stack(
         The scaling of the brain along the z dimension (applied on loading
         before return).
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
@@ -232,11 +232,11 @@ def load_nii(src_path, as_array=False, as_numpy=False):
     src_path : str
         The path to the nifty file on the filesystem.
 
-    as_array : bool
+    as_array : bool, optional
         Whether to convert the brain to a numpy array or keep it as a nifty
         object.
 
-    as_numpy : bool
+    as_numpy : bool, optional
         Whether to convert the image to a numpy array in memory (rather than a
         memmap).
 
@@ -278,30 +278,30 @@ def load_from_folder(
     src_folder : str
         The source folder containing tiff files.
 
-    x_scaling_factor : float
+    x_scaling_factor : float, optional
         The scaling of the brain along the x dimension (applied on loading
         before return).
 
-    y_scaling_factor : float
+    y_scaling_factor : float, optional
         The scaling of the brain along the y dimension (applied on loading
         before return).
 
-    z_scaling_factor : float
+    z_scaling_factor : float, optional
         The scaling of the brain along the z dimension.
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
 
-    file_extension : str
+    file_extension : str, optional
         Will have to be present in the file names for them to be considered
         part of the sample.
 
-    load_parallel : bool
+    load_parallel : bool, optional
         Use multiprocessing to speed up image loading.
 
-    n_free_cpus : int
+    n_free_cpus : int, optional
         Number of CPU cores to leave free.
 
     Returns
@@ -342,30 +342,30 @@ def load_img_sequence(
         The path to the file containing the ordered list of image paths (one
         per line).
 
-    x_scaling_factor : float
+    x_scaling_factor : float, optional
         The scaling of the brain along the x dimension (applied on loading
         before return).
 
-    y_scaling_factor : float
+    y_scaling_factor : float, optional
         The scaling of the brain along the y dimension (applied on loading
         before return).
 
-    z_scaling_factor : float
+    z_scaling_factor : float, optional
         The scaling of the brain along the z dimension.
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
 
-    load_parallel : bool
+    load_parallel : bool, optional
         Use multiprocessing to speed up image loading.
 
-    sort : bool
+    sort : bool, optional
         If set to true, will perform a natural sort of the file paths in the
         list.
 
-    n_free_cpus : int
+    n_free_cpus : int, optional
         Number of CPU cores to leave free.
 
     Returns
@@ -409,26 +409,26 @@ def load_image_series(
     paths : list
         Ordered list of image paths.
 
-    x_scaling_factor : float
+    x_scaling_factor : float, optional
         The scaling of the brain along the x dimension (applied on loading
         before return).
 
-    y_scaling_factor : float
+    y_scaling_factor : float, optional
         The scaling of the brain along the y dimension (applied on loading
         before return).
 
-    z_scaling_factor : float
+    z_scaling_factor : float, optional
         The scaling of the brain along the z dimension.
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
 
-    load_parallel : bool
+    load_parallel : bool, optional
         Use multiprocessing to speed up image loading.
 
-    n_free_cpus : int
+    n_free_cpus : int, optional
         Number of CPU cores to leave free.
 
     Returns
@@ -474,20 +474,20 @@ def threaded_load_from_sequence(
     paths_sequence : list
         The sorted list of the planes paths on the filesystem.
 
-    x_scaling_factor : float
+    x_scaling_factor : float, optional
         The scaling of the brain along the x dimension (applied on loading
         before return).
 
-    y_scaling_factor : float
+    y_scaling_factor : float, optional
         The scaling of the brain along the y dimension (applied on loading
         before return).
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
 
-    n_free_cpus : int
+    n_free_cpus : int, optional
         Number of CPU cores to leave free.
 
     Returns
@@ -543,15 +543,15 @@ def load_from_paths_sequence(
     paths_sequence : list
         The sorted list of the planes paths on the filesystem.
 
-    x_scaling_factor : float
+    x_scaling_factor : float, optional
         The scaling of the brain along the x dimension (applied on loading
         before return).
 
-    y_scaling_factor : float
+    y_scaling_factor : float, optional
         The scaling of the brain along the y dimension (applied on loading
         before return).
 
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.

--- a/brainglobe_utils/image_io/save.py
+++ b/brainglobe_utils/image_io/save.py
@@ -23,7 +23,7 @@ def to_nii(img, dest_path, scale=None, affine_transform=None):
     dest_path : str
         The path where to save the brain.
 
-    scale : tuple of floats
+    scale : tuple of floats, optional
         A tuple of floats to indicate the 'zooms' of the nifty image.
 
     affine_transform : np.ndarray, optional
@@ -70,8 +70,11 @@ def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):
     path_prefix : str
         The prefix for each plane.
 
-    path_suffix : str
+    path_suffix : str, optional
         The suffix for each plane.
+
+    extension : str, optional
+        The file extension for each plane.
     """
     z_size = img_volume.shape[0]
     pad_width = int(round(z_size / 10)) + 1

--- a/brainglobe_utils/image_io/save.py
+++ b/brainglobe_utils/image_io/save.py
@@ -13,16 +13,22 @@ def to_nii(img, dest_path, scale=None, affine_transform=None):
     # TODO: see if we want also real units scale
 
     """
-    Write the brain volume to disk as nifty image.
+    Write the brain volume to disk as a nifty image.
 
-    :param img: A nifty image object or numpy array brain
-    :param str dest_path: The path where to save the brain.
-    :param tuple scale: A tuple of floats to indicate the 'zooms' of the nifty
-        image
-    :param np.ndarray affine_transform: A 4x4 matrix indicating the transform
-        to save in the metadata of the image
-        (required only if not nibabel input)
-    :return:
+    Parameters
+    ----------
+    img : nifty image object or np.ndarray
+        A nifty image object or numpy array representing a brain.
+
+    dest_path : str
+        The path where to save the brain.
+
+    scale : tuple of floats
+        A tuple of floats to indicate the 'zooms' of the nifty image.
+
+    affine_transform : np.ndarray, optional
+        A 4x4 matrix indicating the transform to save in the metadata of the image.
+        Required only if not nibabel input.
     """
     dest_path = str(dest_path)
     if affine_transform is None:
@@ -36,10 +42,15 @@ def to_nii(img, dest_path, scale=None, affine_transform=None):
 
 def to_tiff(img_volume, dest_path):
     """
-    Saves the image volume (numpy array) to a tiff stack
+    Save the image volume (numpy array) to a tiff stack.
 
-    :param np.ndarray img_volume: The image to be saved
-    :param dest_path: Where to save the tiff stack
+    Parameters
+    ----------
+    img_volume : np.ndarray
+        The image to be saved.
+
+    dest_path : str
+        Where to save the tiff stack.
     """
     dest_path = str(dest_path)
     tifffile.imwrite(dest_path, img_volume)
@@ -48,12 +59,19 @@ def to_tiff(img_volume, dest_path):
 def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):
     """
     Save the image volume (numpy array) as a sequence of tiff planes.
-    Each plane will have a filepath of the following for:
+    Each plane will have a filepath of the following format:
     pathprefix_zeroPaddedIndex_suffix.tif
 
-    :param np.ndarray img_volume: The image to be saved
-    :param str path_prefix:  The prefix for each plane
-    :param str path_suffix: The suffix for each plane
+    Parameters
+    ----------
+    img_volume : np.ndarray
+        The image to be saved.
+
+    path_prefix : str
+        The prefix for each plane.
+
+    path_suffix : str
+        The suffix for each plane.
     """
     z_size = img_volume.shape[0]
     pad_width = int(round(z_size / 10)) + 1
@@ -67,10 +85,15 @@ def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):
 
 def to_nrrd(img_volume, dest_path):
     """
-    Saves the image volume (numpy array) as nrrd
+    Save the image volume (numpy array) as nrrd.
 
-    :param np.ndarray img_volume: The image to be saved
-    :param dest_path: Where to save the nrrd image
+    Parameters
+    ----------
+    img_volume : np.ndarray
+        The image to be saved.
+
+    dest_path : str
+        Where to save the nrrd image.
     """
     dest_path = str(dest_path)
     nrrd.write(dest_path, img_volume)

--- a/brainglobe_utils/image_io/save.py
+++ b/brainglobe_utils/image_io/save.py
@@ -27,8 +27,8 @@ def to_nii(img, dest_path, scale=None, affine_transform=None):
         A tuple of floats to indicate the 'zooms' of the nifty image.
 
     affine_transform : np.ndarray, optional
-        A 4x4 matrix indicating the transform to save in the metadata of the image.
-        Required only if not nibabel input.
+        A 4x4 matrix indicating the transform to save in the metadata of the
+        image. Required only if not nibabel input.
     """
     dest_path = str(dest_path)
     if affine_transform is None:

--- a/brainglobe_utils/image_io/utils.py
+++ b/brainglobe_utils/image_io/utils.py
@@ -8,15 +8,24 @@ class ImageIOLoadException(Exception):
 
 def check_mem(img_byte_size, n_imgs):
     """
-    Check how much memory is available on the system and compares it to the
+    Checks how much memory is available on the system and compares it to the
     size the stack specified by img_byte_size and n_imgs would take
     once loaded
 
     Raises an error in case memory is insufficient to load that stack
 
-    :param int img_byte_size: The size in bytes of an individual image plane
-    :param int n_imgs: The number of image planes to load
-    :raises: BrainLoadException if not enough memory is available
+    Parameters
+    ----------
+    img_byte_size : int
+        The size in bytes of an individual image plane.
+
+    n_imgs : int
+        The number of image planes to load.
+
+    Raises
+    ------
+    BrainLoadException
+        If not enough memory is available.
     """
     total_size = img_byte_size * n_imgs
     free_mem = psutil.virtual_memory().available
@@ -29,11 +38,15 @@ def check_mem(img_byte_size, n_imgs):
 
 def scale_z(volume, scaling_factor):
     """
-    Scale the given brain along the z dimension
+    Scale the given brain along the z dimension.
 
-    :param np.ndarray volume: A brain typically as a numpy array
-    :param float scaling_factor:
-    :return:
+    Parameters
+    ----------
+    volume : np.ndarray
+        A brain, typically as a numpy array.
+
+    scaling_factor : float
+        The z scaling factor.
     """
 
     return zoom(volume, (scaling_factor, 1, 1), order=1)


### PR DESCRIPTION
This PR converts all docstrings in the `image_io` sub-module from reST style to numpydoc style

## References

For https://github.com/brainglobe/brainglobe-utils/issues/19
