### PR TITLE
Handle str and pathlib.Path consistently in image_io

### DIFF
--- a/brainglobe_utils/general/system.py
+++ b/brainglobe_utils/general/system.py
@@ -94,7 +94,7 @@ def get_sorted_file_paths(file_path, file_extension=None, encoding=None):
 
     Parameters
     ----------
-    file_path : list of str or str
+    file_path : list of str or str or pathlib.Path
         List of file paths, or path of a text file containing these paths,
         or path of a directory containing files.
 

--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -112,7 +112,7 @@ def load_any(
             sort=sort_input_file,
             n_free_cpus=n_free_cpus,
         )
-    elif src_path.suffix == ".tif" or src_path.suffix == ".tiff":
+    elif src_path.suffix in [".tif", ".tiff"]:
         logging.debug("Data type is: tif stack")
         img = load_img_stack(
             src_path,
@@ -124,7 +124,7 @@ def load_any(
     elif src_path.suffix == ".nrrd":
         logging.debug("Data type is: nrrd")
         img = load_nrrd(src_path)
-    elif src_path.suffix == ".nii" or src_path.suffix == ".nii.gz":
+    elif src_path.suffix in [".nii", ".nii.gz"]:
         logging.debug("Data type is: NifTI")
         img = load_nii(src_path, as_array=True, as_numpy=as_numpy)
     else:

--- a/brainglobe_utils/image_io/save.py
+++ b/brainglobe_utils/image_io/save.py
@@ -81,18 +81,16 @@ def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):
     extension : str, optional
         The file extension for each plane.
     """
-    path_prefix = Path(path_prefix)
-    directory = path_prefix.parent
-    filename = path_prefix.name
+    if isinstance(path_prefix, Path):
+        path_prefix = str(path_prefix.resolve())
 
     z_size = img_volume.shape[0]
     pad_width = int(round(z_size / 10)) + 1
     for i in range(z_size):
         img = img_volume[i, :, :]
-        filename = (
-            f"{filename}_{str(i).zfill(pad_width)}{path_suffix}{extension}"
+        dest_path = (
+            f"{path_prefix}_{str(i).zfill(pad_width)}{path_suffix}{extension}"
         )
-        dest_path = directory / filename
         tifffile.imwrite(dest_path, img)
 
 

--- a/brainglobe_utils/image_io/save.py
+++ b/brainglobe_utils/image_io/save.py
@@ -132,7 +132,7 @@ def save_any(img_volume, dest_path):
     if dest_path.is_dir():
         to_tiffs(img_volume, dest_path / "image")
 
-    elif dest_path.suffix == ".tif" or dest_path.suffix == ".tiff":
+    elif dest_path.suffix in [".tif", ".tiff"]:
         to_tiff(img_volume, dest_path)
 
     elif dest_path.suffix == ".nrrd":

--- a/tests/tests/test_image_io.py
+++ b/tests/tests/test_image_io.py
@@ -40,7 +40,7 @@ def txt_path(tmp_path, array_3d):
     # Write tiff sequence to sub-folder
     sub_dir = directory / "sub"
     sub_dir.mkdir()
-    save.to_tiffs(array_3d, str(sub_dir / "image"))
+    save.to_tiffs(array_3d, sub_dir / "image")
 
     # Write txt file containing all tiff file paths (one per line)
     tiff_paths = sorted(sub_dir.iterdir())
@@ -74,7 +74,7 @@ def test_tiff_io(tmp_path, image_array):
     """
     dest_path = tmp_path / "image_array.tiff"
     save.save_any(image_array, dest_path)
-    reloaded = load.load_any(str(dest_path))
+    reloaded = load.load_any(dest_path)
 
     assert (reloaded == image_array).all()
 
@@ -92,7 +92,7 @@ def test_3d_tiff_scaling(
     dest_path = tmp_path / "image_array.tiff"
     save.save_any(array_3d, dest_path)
     reloaded = load.load_any(
-        str(dest_path),
+        dest_path,
         x_scaling_factor=x_scaling_factor,
         y_scaling_factor=y_scaling_factor,
         z_scaling_factor=z_scaling_factor,
@@ -118,7 +118,7 @@ def test_tiff_sequence_io(tmp_path, array_3d, load_parallel):
     save.save_any(array_3d, tmp_path)
     assert len(list(tmp_path.glob("*.tif"))) == array_3d.shape[0]
 
-    reloaded_array = load.load_any(str(tmp_path), load_parallel=load_parallel)
+    reloaded_array = load.load_any(tmp_path, load_parallel=load_parallel)
     assert (reloaded_array == array_3d).all()
 
 
@@ -134,7 +134,7 @@ def test_tiff_sequence_scaling(
     """
     save.save_any(array_3d, tmp_path)
     reloaded_array = load.load_any(
-        str(tmp_path),
+        tmp_path,
         x_scaling_factor=x_scaling_factor,
         y_scaling_factor=y_scaling_factor,
         z_scaling_factor=z_scaling_factor,
@@ -155,7 +155,7 @@ def test_sort_img_sequence_from_txt(shuffled_txt_path, array_3d, sort):
     """
     # Load image from shuffled paths in text file
     reloaded_array = load.load_img_sequence(
-        str(shuffled_txt_path), 1, 1, 1, sort=sort
+        shuffled_txt_path, 1, 1, 1, sort=sort
     )
     if sort:
         assert (reloaded_array == array_3d).all()
@@ -168,7 +168,7 @@ def test_nii_io(tmp_path, array_3d):
     Test that a 3D image can be written and read correctly as nii with scale
     (keeping it as a nifty object with no numpy conversion on loading)
     """
-    nii_path = str(tmp_path / "test_array.nii")
+    nii_path = tmp_path / "test_array.nii"
     scale = (5, 5, 5)
     save.to_nii(array_3d, nii_path, scale=scale)
     reloaded = load.load_nii(nii_path)
@@ -183,11 +183,12 @@ def test_nii_read_to_numpy(tmp_path, array_3d):
     """
     nii_path = tmp_path / "test_array.nii"
     save.save_any(array_3d, nii_path)
-    reloaded_array = load.load_any(str(nii_path), as_numpy=True)
+    reloaded_array = load.load_any(nii_path, as_numpy=True)
 
     assert (reloaded_array == array_3d).all()
 
 
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
 @pytest.mark.parametrize(
     "file_name",
     [
@@ -198,23 +199,30 @@ def test_nii_read_to_numpy(tmp_path, array_3d):
         pytest.param("", id="dir of tiffs"),
     ],
 )
-def test_save_and_load_any(tmp_path, array_3d, file_name):
+def test_save_and_load_any(tmp_path, array_3d, file_name, use_path):
     """
     Test that save_any/load_any can write/read all required image
-    file types.
+    file types. Tests using both string and pathlib.Path input.
     """
-    src_path = tmp_path / file_name
+    if use_path:
+        src_path = tmp_path / file_name
+    else:
+        src_path = str(tmp_path / file_name)
     save.save_any(array_3d, src_path)
 
-    assert (load.load_any(str(src_path)) == array_3d).all()
+    assert (load.load_any(src_path) == array_3d).all()
 
 
-def test_load_any_txt(txt_path, array_3d):
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
+def test_load_any_txt(txt_path, array_3d, use_path):
     """
     Test that load_any can read a tiff sequence from a text file containing an
-    ordered list of the tiff file paths (one per line)
+    ordered list of the tiff file paths (one per line). Tests using both
+    string and pathlib.Path input.
     """
-    assert (load.load_any(str(txt_path)) == array_3d).all()
+    if not use_path:
+        txt_path = str(txt_path)
+    assert (load.load_any(txt_path) == array_3d).all()
 
 
 def test_load_any_error(tmp_path):
@@ -222,7 +230,7 @@ def test_load_any_error(tmp_path):
     Test that load_any throws an error for an unknown file extension
     """
     with pytest.raises(NotImplementedError):
-        load.load_any(str(tmp_path / "test.unknown"))
+        load.load_any(tmp_path / "test.unknown")
 
 
 def test_save_any_error(tmp_path, array_3d):
@@ -230,7 +238,7 @@ def test_save_any_error(tmp_path, array_3d):
     Test that save_any throws an error for an unknown file extension
     """
     with pytest.raises(NotImplementedError):
-        save.save_any(array_3d, str(tmp_path / "test.unknown"))
+        save.save_any(array_3d, tmp_path / "test.unknown")
 
 
 def test_scale_z(array_3d):
@@ -247,7 +255,7 @@ def test_image_size_dir(tmp_path, array_3d):
     """
     save.save_any(array_3d, tmp_path)
 
-    image_shape = load.get_size_image_from_file_paths(str(tmp_path))
+    image_shape = load.get_size_image_from_file_paths(tmp_path)
     assert image_shape["x"] == array_3d.shape[2]
     assert image_shape["y"] == array_3d.shape[1]
     assert image_shape["z"] == array_3d.shape[0]
@@ -258,7 +266,7 @@ def test_image_size_txt(txt_path, array_3d):
     Test that image size can be detected from a text file containing the paths
     of a sequence of 2D tiffs
     """
-    image_shape = load.get_size_image_from_file_paths(str(txt_path))
+    image_shape = load.get_size_image_from_file_paths(txt_path)
     assert image_shape["x"] == array_3d.shape[2]
     assert image_shape["y"] == array_3d.shape[1]
     assert image_shape["z"] == array_3d.shape[0]

--- a/tests/tests/test_image_io.py
+++ b/tests/tests/test_image_io.py
@@ -68,13 +68,20 @@ def shuffled_txt_path(txt_path):
     return txt_path
 
 
-def test_tiff_io(tmp_path, image_array):
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
+def test_tiff_io(tmp_path, image_array, use_path):
     """
-    Test that a 2D/3D tiff can be written and read correctly
+    Test that a 2D/3D tiff can be written and read correctly, using string
+    or pathlib.Path input.
     """
-    dest_path = tmp_path / "image_array.tiff"
-    save.save_any(image_array, dest_path)
-    reloaded = load.load_any(dest_path)
+    filename = "image_array.tiff"
+    if use_path:
+        dest_path = tmp_path / filename
+    else:
+        dest_path = str(tmp_path / filename)
+
+    save.to_tiff(image_array, dest_path)
+    reloaded = load.load_img_stack(dest_path, 1, 1, 1)
 
     assert (reloaded == image_array).all()
 
@@ -103,6 +110,7 @@ def test_3d_tiff_scaling(
     assert reloaded.shape[2] == array_3d.shape[2] * x_scaling_factor
 
 
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
 @pytest.mark.parametrize(
     "load_parallel",
     [
@@ -110,15 +118,25 @@ def test_3d_tiff_scaling(
         pytest.param(False, id="no parallel loading"),
     ],
 )
-def test_tiff_sequence_io(tmp_path, array_3d, load_parallel):
+def test_tiff_sequence_io(tmp_path, array_3d, load_parallel, use_path):
     """
     Test that a 3D image can be written and read correctly as a sequence
-    of 2D tiffs (with or without parallel loading)
+    of 2D tiffs (with or without parallel loading). Tests using both
+    string and pathlib.Path input.
     """
-    save.save_any(array_3d, tmp_path)
+    prefix = "image"
+    dest_path = tmp_path / prefix
+    dir_path = tmp_path
+    if not use_path:
+        dest_path = str(dest_path)
+        dir_path = str(dir_path)
+
+    save.to_tiffs(array_3d, dest_path)
     assert len(list(tmp_path.glob("*.tif"))) == array_3d.shape[0]
 
-    reloaded_array = load.load_any(tmp_path, load_parallel=load_parallel)
+    reloaded_array = load.load_from_folder(
+        dir_path, load_parallel=load_parallel
+    )
     assert (reloaded_array == array_3d).all()
 
 
@@ -145,6 +163,20 @@ def test_tiff_sequence_scaling(
     assert reloaded_array.shape[2] == array_3d.shape[2] * x_scaling_factor
 
 
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
+def test_load_img_sequence_from_txt(txt_path, array_3d, use_path):
+    """
+    Test that a tiff sequence can be read from a text file containing an
+    ordered list of the tiff file paths (one per line). Tests using both str
+    and pathlib.Path input.
+    """
+    if not use_path:
+        txt_path = str(txt_path)
+
+    reloaded_array = load.load_img_sequence(txt_path)
+    assert (reloaded_array == array_3d).all()
+
+
 @pytest.mark.parametrize(
     "sort",
     [True, False],
@@ -163,12 +195,19 @@ def test_sort_img_sequence_from_txt(shuffled_txt_path, array_3d, sort):
         assert not (reloaded_array == array_3d).all()
 
 
-def test_nii_io(tmp_path, array_3d):
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
+def test_nii_io(tmp_path, array_3d, use_path):
     """
     Test that a 3D image can be written and read correctly as nii with scale
-    (keeping it as a nifty object with no numpy conversion on loading)
+    (keeping it as a nifty object with no numpy conversion on loading).
+    Tests using both str and pathlib.Path input.
     """
-    nii_path = tmp_path / "test_array.nii"
+    filename = "test_array.nii"
+    if use_path:
+        nii_path = tmp_path / filename
+    else:
+        nii_path = str(tmp_path / filename)
+
     scale = (5, 5, 5)
     save.to_nii(array_3d, nii_path, scale=scale)
     reloaded = load.load_nii(nii_path)
@@ -186,6 +225,22 @@ def test_nii_read_to_numpy(tmp_path, array_3d):
     reloaded_array = load.load_any(nii_path, as_numpy=True)
 
     assert (reloaded_array == array_3d).all()
+
+
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
+def test_nrrd_io(tmp_path, array_3d, use_path):
+    """
+    Test that a 3D image can be written and read correctly as nrrd, using both
+    str and pathlib.Path input.
+    """
+    filename = "test_array.nrrd"
+    if use_path:
+        nrrd_path = tmp_path / filename
+    else:
+        nrrd_path = str(tmp_path / filename)
+
+    save.to_nrrd(array_3d, nrrd_path)
+    assert (load.load_nrrd(nrrd_path) == array_3d).all()
 
 
 @pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The load/save functions in `image_io` currently only specify `str` filepaths in their docstrings, although some can also accept `pathlib.Path`. 

**What does this PR do?**
This PR ensures that all load/save functions in `image_io` consistently handle both `str` and `pathlib.Path`. It favours using `pathlib.Path` internally wherever possible.

## References

Closes https://github.com/brainglobe/brainglobe-utils/issues/47

## How has this PR been tested?

`image_io` tests were updated so that all load/save functions are tested with both `pathlib.Path` and `str`. 

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

All relevant `image_io` docstrings were updated.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
