### PR TITLE
Support single z-stack tif file for input

### DIFF
--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -686,28 +686,27 @@ def get_size_image_from_file_paths(file_path, file_extension="tif"):
     file_path = Path(file_path)
     if file_path.suffix in [".tif", ".tiff"]:
         # read just the metadata
-        tiff = tifffile.TiffFile(file_path)
-        if not len(tiff.series):
-            raise ValueError(
-                f"Attempted to load {file_path} but couldn't read a z-stack"
-            )
-        if len(tiff.series) != 1:
-            raise ValueError(
-                f"Attempted to load {file_path} but found multiple stacks"
-            )
+        with tifffile.TiffFile(file_path) as tiff:
+            if not len(tiff.series):
+                raise ValueError(
+                    f"Attempted to load {file_path} but didn't find a z-stack"
+                )
+            if len(tiff.series) != 1:
+                raise ValueError(
+                    f"Attempted to load {file_path} but found multiple stacks"
+                )
 
-        shape = tiff.series[0].shape
-        axes = tiff.series[0].axes.lower()
-        # axes is e.g. "ZXY"
-        indices = {ax: i for i, ax in enumerate(axes)}
-        if set(axes) != {"x", "y", "z"}:
-            raise ValueError(
-                f"Attempted to load {file_path} but didn't find a xyz-stack. "
-                f"Found {axes} axes with shape {shape}"
-            )
+            shape = tiff.series[0].shape
+            axes = tiff.series[0].axes.lower()
+            # axes is e.g. "zxy"
+            if set(axes) != {"x", "y", "z"}:
+                raise ValueError(
+                    f"Attempted to load {file_path} but didn't find a "
+                    f"xyz-stack. Found {axes} axes with shape {shape}"
+                )
 
-        image_shape = {name: shape[i] for name, i in indices.items()}
-        return image_shape
+            image_shape = {ax: n for ax, n in zip(axes, shape)}
+            return image_shape
 
     img_paths = get_sorted_file_paths(file_path, file_extension=file_extension)
     z_shape = len(img_paths)

--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -684,7 +684,7 @@ def get_size_image_from_file_paths(file_path, file_extension="tif"):
         Dict of image sizes.
     """
     file_path = Path(file_path)
-    if file_path.name.endswith(".tif") or file_path.name.endswith(".tiff"):
+    if file_path.suffix in [".tif", ".tiff"]:
         # read just the metadata
         tiff = tifffile.TiffFile(file_path)
         if not len(tiff.series):

--- a/brainglobe_utils/image_io/load.py
+++ b/brainglobe_utils/image_io/load.py
@@ -703,7 +703,8 @@ def get_size_image_from_file_paths(file_path, file_extension="tif"):
         if set(axes) != {"x", "y", "z"}:
             raise ValueError(
                 f"Attempted to load {file_path} but didn't find a xyz-stack. "
-                f"Found {axes} axes with shape {shape}")
+                f"Found {axes} axes with shape {shape}"
+            )
 
         image_shape = {name: shape[i] for name, i in indices.items()}
         return image_shape

--- a/brainglobe_utils/image_io/save.py
+++ b/brainglobe_utils/image_io/save.py
@@ -58,7 +58,12 @@ def to_tiff(img_volume, dest_path, photometric="minisblack"):
         Use 'minisblack' (default) for grayscale and 'rgb' for rgb
     """
     dest_path = Path(dest_path)
-    tifffile.imwrite(dest_path, img_volume, photometric=photometric)
+    tifffile.imwrite(
+        dest_path,
+        img_volume,
+        photometric=photometric,
+        metadata={"axes": "ZYX"},
+    )
 
 
 def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):

--- a/tests/tests/test_image_io.py
+++ b/tests/tests/test_image_io.py
@@ -350,6 +350,19 @@ def test_image_size_dir(tmp_path, array_3d):
     assert image_shape["z"] == array_3d.shape[0]
 
 
+def test_image_size_tiff_stack(tmp_path, array_3d):
+    """
+    Test that image size can be detected from a directory of 2D tiffs
+    """
+    filename = tmp_path.joinpath("image_size_tiff_stack.tif")
+    save.save_any(array_3d, filename)
+
+    image_shape = load.get_size_image_from_file_paths(filename)
+    assert image_shape["x"] == array_3d.shape[2]
+    assert image_shape["y"] == array_3d.shape[1]
+    assert image_shape["z"] == array_3d.shape[0]
+
+
 def test_image_size_txt(txt_path, array_3d):
     """
     Test that image size can be detected from a text file containing the paths


### PR DESCRIPTION
This is part of this PR: https://github.com/brainglobe/cellfinder/pull/397 and https://github.com/brainglobe/brainglobe-workflows/pull/88.