### PR TITLE
Update Pathlib usage and docstrings

### DIFF
--- a/brainglobe_utils/IO/cells.py
+++ b/brainglobe_utils/IO/cells.py
@@ -88,7 +88,9 @@ def raise_cell_read_error(cells_file_path):
     )
 
 
-def get_cells_xml(xml_file_path: Union[str, Path], cells_only: Optional[bool] = False):
+def get_cells_xml(
+    xml_file_path: Union[str, Path], cells_only: Optional[bool] = False
+):
     """
     Read cells from an xml file.
 
@@ -162,7 +164,9 @@ def get_cells_yml(
     return cells
 
 
-def get_cells_dir(cells_file_path: Union[str, Path], cell_type: Optional[bool] = None):
+def get_cells_dir(
+    cells_file_path: Union[str, Path], cell_type: Optional[bool] = None
+):
     """
     Read cells from a directory. Cells will be created based on the filenames
     of files in the directory, one cell per file.

--- a/brainglobe_utils/IO/cells.py
+++ b/brainglobe_utils/IO/cells.py
@@ -88,7 +88,7 @@ def raise_cell_read_error(cells_file_path):
     )
 
 
-def get_cells_xml(xml_file_path: Path, cells_only: Optional[bool] = False):
+def get_cells_xml(xml_file_path: Union[str, Path], cells_only: Optional[bool] = False):
     """
     Read cells from an xml file.
 
@@ -122,7 +122,7 @@ def get_cells_xml(xml_file_path: Path, cells_only: Optional[bool] = False):
 
 
 def get_cells_yml(
-    cells_file_path: Path,
+    cells_file_path: Union[str, Path],
     ignore_type: Optional[bool] = False,
     marker: Optional[str] = "markers",
 ):
@@ -162,7 +162,7 @@ def get_cells_yml(
     return cells
 
 
-def get_cells_dir(cells_file_path: Path, cell_type: Optional[bool] = None):
+def get_cells_dir(cells_file_path: Union[str, Path], cell_type: Optional[bool] = None):
     """
     Read cells from a directory. Cells will be created based on the filenames
     of files in the directory, one cell per file.
@@ -234,8 +234,8 @@ def save_cells(
 
 
 def cells_to_xml(
-    cells: Cell,
-    xml_file_path: Path,
+    cells: List[Cell],
+    xml_file_path: Union[str, Path],
     indentation_str: Optional[str] = "  ",
     artifact_keep: Optional[bool] = True,
 ):

--- a/brainglobe_utils/IO/cells.py
+++ b/brainglobe_utils/IO/cells.py
@@ -7,7 +7,7 @@ Christian Niedworok (https://github.com/cniedwor).
 
 import logging
 import os
-import pathlib
+from pathlib import Path
 from typing import List, Optional, Union
 from xml.dom import minidom
 from xml.etree import ElementTree
@@ -88,7 +88,7 @@ def raise_cell_read_error(cells_file_path):
     )
 
 
-def get_cells_xml(xml_file_path, cells_only=False):
+def get_cells_xml(xml_file_path: Path, cells_only: Optional[bool] = False):
     """
     Read cells from an xml file.
 
@@ -121,7 +121,11 @@ def get_cells_xml(xml_file_path, cells_only=False):
     return cells
 
 
-def get_cells_yml(cells_file_path, ignore_type=False, marker="markers"):
+def get_cells_yml(
+    cells_file_path: Path,
+    ignore_type: Optional[bool] = False,
+    marker: Optional[str] = "markers",
+):
     """
     Read cells from a yml file.
 
@@ -158,7 +162,7 @@ def get_cells_yml(cells_file_path, ignore_type=False, marker="markers"):
     return cells
 
 
-def get_cells_dir(cells_file_path, cell_type=None):
+def get_cells_dir(cells_file_path: Path, cell_type: Optional[bool] = None):
     """
     Read cells from a directory. Cells will be created based on the filenames
     of files in the directory, one cell per file.
@@ -230,7 +234,10 @@ def save_cells(
 
 
 def cells_to_xml(
-    cells, xml_file_path, indentation_str="  ", artifact_keep=True
+    cells: Cell,
+    xml_file_path: Path,
+    indentation_str: Optional[str] = "  ",
+    artifact_keep: Optional[bool] = True,
 ):
     """
     Save cells to an xml file.
@@ -263,7 +270,7 @@ def cells_to_dataframe(cells: List[Cell]) -> pd.DataFrame:
     return pd.DataFrame([c.to_dict() for c in cells])
 
 
-def cells_to_csv(cells: List[Cell], csv_file_path: Union[str, pathlib.Path]):
+def cells_to_csv(cells: List[Cell], csv_file_path: Union[str, Path]):
     """Save cells to csv file"""
     df = cells_to_dataframe(cells)
     df.to_csv(csv_file_path)

--- a/brainglobe_utils/IO/surfaces.py
+++ b/brainglobe_utils/IO/surfaces.py
@@ -1,4 +1,14 @@
-def marching_cubes_to_obj(marching_cubes_out, output_file):
+from typing import TYPE_CHECKING, Tuple, Union
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from numpy.typing import NDArray
+
+
+def marching_cubes_to_obj(
+    marching_cubes_out: Tuple["NDArray"], output_file: Union[str, "Path"]
+):
     """
     Saves the output of skimage.measure.marching_cubes as an .obj file
 

--- a/brainglobe_utils/IO/surfaces.py
+++ b/brainglobe_utils/IO/surfaces.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING, Tuple, Union
+from pathlib import Path
+from typing import Tuple, Union
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 
 def marching_cubes_to_obj(

--- a/brainglobe_utils/IO/surfaces.py
+++ b/brainglobe_utils/IO/surfaces.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 
 
 def marching_cubes_to_obj(
-    marching_cubes_out: Tuple["NDArray"], output_file: Union[str, "Path"]
+    marching_cubes_out: Tuple[NDArray], output_file: Union[str, Path]
 ):
     """
     Saves the output of skimage.measure.marching_cubes as an .obj file

--- a/brainglobe_utils/IO/yaml.py
+++ b/brainglobe_utils/IO/yaml.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Union
 import yaml
 
 
-def read_yaml_section(yaml_file: Union[str, "Path"], section: str) -> Any:
+def read_yaml_section(yaml_file: Union[str, Path], section: str) -> Any:
     """
     Read section from yaml file.
 
@@ -24,7 +24,7 @@ def read_yaml_section(yaml_file: Union[str, "Path"], section: str) -> Any:
     return contents
 
 
-def open_yaml(yaml_file: Union[str, "Path"]) -> Dict[str, Any]:
+def open_yaml(yaml_file: Union[str, Path]) -> Dict[str, Any]:
     """
     Read the contents of a yaml file.
 
@@ -45,7 +45,7 @@ def open_yaml(yaml_file: Union[str, "Path"]) -> Dict[str, Any]:
 
 def save_yaml(
     yaml_contents: Dict[str, Any],
-    output_file: Union[str, "Path"],
+    output_file: Union[str, Path],
     default_flow_style: Optional[bool] = False,
 ):
     """

--- a/brainglobe_utils/IO/yaml.py
+++ b/brainglobe_utils/IO/yaml.py
@@ -1,7 +1,14 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
 import yaml
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def read_yaml_section(yaml_file, section):
+
+def read_yaml_section(
+    yaml_file: Union[str, "Path"], section: str
+) -> Dict[str, Any]:
     """
     Read section from yaml file.
 
@@ -21,7 +28,7 @@ def read_yaml_section(yaml_file, section):
     return contents
 
 
-def open_yaml(yaml_file):
+def open_yaml(yaml_file: Union[str, "Path"]) -> Dict[str, Any]:
     """
     Read the contents of a yaml file.
 
@@ -40,7 +47,11 @@ def open_yaml(yaml_file):
     return yaml_contents
 
 
-def save_yaml(yaml_contents, output_file, default_flow_style=False):
+def save_yaml(
+    yaml_contents: Dict[str, Any],
+    output_file: Union[str, "Path"],
+    default_flow_style: Optional[bool] = False,
+):
     """
     Save contents to a yaml file.
 

--- a/brainglobe_utils/IO/yaml.py
+++ b/brainglobe_utils/IO/yaml.py
@@ -1,14 +1,10 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
 
 import yaml
 
-if TYPE_CHECKING:
-    from pathlib import Path
 
-
-def read_yaml_section(
-    yaml_file: Union[str, "Path"], section: str
-) -> Dict[str, Any]:
+def read_yaml_section(yaml_file: Union[str, "Path"], section: str) -> Any:
     """
     Read section from yaml file.
 

--- a/brainglobe_utils/general/pathlib.py
+++ b/brainglobe_utils/general/pathlib.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def append_to_pathlib_stem(path: "Path", string_to_append: str):
+def append_to_pathlib_stem(path: Path, string_to_append: str):
     """
     Appends a string to the stem of a pathlib object.
 

--- a/brainglobe_utils/general/pathlib.py
+++ b/brainglobe_utils/general/pathlib.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 
 def append_to_pathlib_stem(path: "Path", string_to_append: str):

--- a/brainglobe_utils/general/pathlib.py
+++ b/brainglobe_utils/general/pathlib.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def append_to_pathlib_stem(path: "Path", string_to_append):
+def append_to_pathlib_stem(path: "Path", string_to_append: str):
     """
     Appends a string to the stem of a pathlib object.
 

--- a/brainglobe_utils/general/pathlib.py
+++ b/brainglobe_utils/general/pathlib.py
@@ -1,4 +1,10 @@
-def append_to_pathlib_stem(path, string_to_append):
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def append_to_pathlib_stem(path: "Path", string_to_append):
     """
     Appends a string to the stem of a pathlib object.
 

--- a/brainglobe_utils/general/string.py
+++ b/brainglobe_utils/general/string.py
@@ -1,11 +1,9 @@
-from typing import TYPE_CHECKING, Optional
+from pathlib import Path
+from typing import Optional
 
 from natsort import natsorted
 
 from brainglobe_utils.general import list
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def get_text_lines(

--- a/brainglobe_utils/general/string.py
+++ b/brainglobe_utils/general/string.py
@@ -1,15 +1,20 @@
+from typing import TYPE_CHECKING, Optional
+
 from natsort import natsorted
 
 from brainglobe_utils.general import list
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 def get_text_lines(
-    file,
-    return_lines=None,
-    rstrip=True,
-    sort=False,
-    remove_empty_lines=True,
-    encoding="utf8",
+    file: "Path",
+    return_lines: Optional[int] = None,
+    rstrip: Optional[bool] = True,
+    sort: Optional[bool] = False,
+    remove_empty_lines: Optional[bool] = True,
+    encoding: Optional[str] = "utf8",
 ):
     """
     Return only the nth line of a text file.

--- a/brainglobe_utils/general/string.py
+++ b/brainglobe_utils/general/string.py
@@ -7,7 +7,7 @@ from brainglobe_utils.general import list
 
 
 def get_text_lines(
-    file: "Path",
+    file: Path,
     return_lines: Optional[int] = None,
     rstrip: Optional[bool] = True,
     sort: Optional[bool] = False,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

Standardises our imports of `pathlib` `Path`s and avoids importing the whole module when we only need the `Path` class.

**What does this PR do?**

- Standardises our import of `Path` to `from pathlib import Path` across the package.
- Updates / adds docstrings to a few functions that reply on `Path` inputs.

## References

No issues, but picked up on in a comment on https://github.com/brainglobe/brainglobe-utils/pull/65#issuecomment-2046963476

## How has this PR been tested?

Tests pass locally. No package functionality should be changed, either.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
