### PR TITLE
Expand header_widget to include doc path, citation and help text

### DIFF
--- a/brainglobe_utils/qtpy/logo.py
+++ b/brainglobe_utils/qtpy/logo.py
@@ -6,18 +6,51 @@ from qtpy.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QWidget
 def _docs_links_widget(
     package_name: str,
     package_tagline: str,
-    tutorial_file_name: str,
+    tutorial_file_name: str = None,
+    documentation_path: str = None,
+    citation_doi: str = None,
+    github_repo_name: str = None,
+    help_text: str = None,
     parent: QWidget = None,
 ):
-    _docs_links_html = f"""
-    <h3>
-    <p>{package_tagline}</p>
-    <p><a href="https://brainglobe.info" style="color:gray;">Website</a></p>
-    <p><a href="https://brainglobe.info/tutorials/{tutorial_file_name}" style="color:gray;">Tutorial</a></p>
-    <p><a href="https://github.com/brainglobe/{package_name}" style="color:gray;">Source</a></p>
-    </h3>
-    """  # noqa: E501
-    docs_links_widget = QLabel(_docs_links_html, parent=parent)
+    lines = [
+        "<h3>",
+        f"<p>{package_tagline}</p>",
+        "<p><a href='https://brainglobe.info' style='color:gray;'>"
+        "Website</a></p>",
+    ]
+
+    if tutorial_file_name:
+        lines.append(
+            f"<p>"
+            f"<a href='https://brainglobe.info/tutorials/{tutorial_file_name}'"
+            f" style='color:gray;'>Tutorial</a></p>"
+        )
+
+    if documentation_path:
+        lines.append(
+            f"<p><a href="
+            f"'https://brainglobe.info/documentation/{documentation_path}' "
+            f"style='color:gray;'>Documentation</a></p>"
+        )
+
+    if github_repo_name is None:
+        github_repo_name = package_name
+    lines.append(
+        f"<p><a href='https://github.com/brainglobe/{github_repo_name}' "
+        f"style='color:gray;'>Source</a></p>"
+    )
+
+    if citation_doi:
+        lines.append(
+            f"<p><a href='{citation_doi}' style='color:gray;'>Citation</a></p>"
+        )
+
+    if help_text:
+        lines.append(f"<p><small>{help_text}</small></p>")
+
+    lines.append("</h3>")
+    docs_links_widget = QLabel("\n".join(lines), parent=parent)
     docs_links_widget.setOpenExternalLinks(True)
     return docs_links_widget
 
@@ -38,9 +71,13 @@ def _logo_widget(package_name: str, parent: QWidget = None):
 def header_widget(
     package_name: str,
     package_tagline: str,
-    tutorial_file_name: str,
+    tutorial_file_name: str = None,
+    documentation_path: str = None,
+    citation_doi: str = None,
+    github_repo_name: str = None,
+    help_text: str = None,
     parent: QWidget = None,
-):
+) -> QGroupBox:
     """
     Render HTML in a QGroupBox with a BrainGlobe logo and links to the docs
      and source code.
@@ -51,9 +88,21 @@ def header_widget(
         The name of the package, e.g. "brainrender-napari"
     package_tagline : str
         The tagline for the package
-    tutorial_file_name : str
+    tutorial_file_name : str, optional
         The name of the tutorial file (must include .html),
-         e.g. "brainrender-qtpy.html": str
+         e.g. "brainrender-qtpy.html"
+    documentation_path : str, optional
+        The relative path of a documentation file (must include .html),
+        e.g. "cellfinder/user-guide/napari-plugin/index.html"
+    citation_doi : str, optional
+        Doi of citation e.g. "https://doi.org/10.1371/journal.pcbi.1009074"
+    github_repo_name : str, optional
+        Name of github repository inside the BrainGlobe organisation
+        (https://github.com/brainglobe). Only necessary if the github
+        repository name isn't the same as the package name.
+    help_text : str, optional
+        Help text to display at the bottom or the header e.g.
+        "For help, hover the cursor over each parameter."
     parent : QWidget
         The parent widget, defaults to None
 
@@ -69,7 +118,14 @@ def header_widget(
     box.layout().addWidget(_logo_widget(package_name, parent=box))
     box.layout().addWidget(
         _docs_links_widget(
-            package_name, package_tagline, tutorial_file_name, parent=box
+            package_name,
+            package_tagline,
+            tutorial_file_name,
+            documentation_path,
+            citation_doi,
+            github_repo_name,
+            help_text,
+            parent=box,
         )
     )
 

--- a/brainglobe_utils/qtpy/logo.py
+++ b/brainglobe_utils/qtpy/logo.py
@@ -1,4 +1,5 @@
 from importlib.resources import files
+from typing import Optional
 
 from qtpy.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QWidget
 
@@ -6,12 +7,12 @@ from qtpy.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QWidget
 def _docs_links_widget(
     package_name: str,
     package_tagline: str,
-    tutorial_file_name: str = None,
-    documentation_path: str = None,
-    citation_doi: str = None,
-    github_repo_name: str = None,
-    help_text: str = None,
-    parent: QWidget = None,
+    tutorial_file_name: Optional[str] = None,
+    documentation_path: Optional[str] = None,
+    citation_doi: Optional[str] = None,
+    github_repo_name: Optional[str] = None,
+    help_text: Optional[str] = None,
+    parent: Optional[QWidget] = None,
 ):
     lines = [
         "<h3>",
@@ -55,7 +56,7 @@ def _docs_links_widget(
     return docs_links_widget
 
 
-def _logo_widget(package_name: str, parent: QWidget = None):
+def _logo_widget(package_name: str, parent: Optional[QWidget] = None):
     brainglobe_logo = files("brainglobe_utils").joinpath("qtpy/brainglobe.png")
 
     _logo_html = f"""
@@ -71,12 +72,12 @@ def _logo_widget(package_name: str, parent: QWidget = None):
 def header_widget(
     package_name: str,
     package_tagline: str,
-    tutorial_file_name: str = None,
-    documentation_path: str = None,
-    citation_doi: str = None,
-    github_repo_name: str = None,
-    help_text: str = None,
-    parent: QWidget = None,
+    tutorial_file_name: Optional[str] = None,
+    documentation_path: Optional[str] = None,
+    citation_doi: Optional[str] = None,
+    github_repo_name: Optional[str] = None,
+    help_text: Optional[str] = None,
+    parent: Optional[QWidget] = None,
 ) -> QGroupBox:
     """
     Render HTML in a QGroupBox with a BrainGlobe logo and links to the docs
@@ -92,7 +93,8 @@ def header_widget(
         The name of the tutorial file (must include .html),
          e.g. "brainrender-qtpy.html"
     documentation_path : str, optional
-        The relative path of a documentation file (must include .html),
+        Path of documentation file relative to
+        https://brainglobe.info/documentation/ (must include .html),
         e.g. "cellfinder/user-guide/napari-plugin/index.html"
     citation_doi : str, optional
         Doi of citation e.g. "https://doi.org/10.1371/journal.pcbi.1009074"
@@ -103,7 +105,7 @@ def header_widget(
     help_text : str, optional
         Help text to display at the bottom or the header e.g.
         "For help, hover the cursor over each parameter."
-    parent : QWidget
+    parent : QWidget, optional
         The parent widget, defaults to None
 
     Returns

--- a/tests/tests/test_qtpy/test_logo.py
+++ b/tests/tests/test_qtpy/test_logo.py
@@ -4,16 +4,29 @@ from brainglobe_utils.qtpy.logo import header_widget
 def test_logo(qtbot):
     package_name = "test"
     package_tagline = "Tagline"
-    package_tutorial = "test.html"
+    tutorial_file_name = "test-tutorial.html"
+    documentation_path = "test-docs/test.html"
+    citation_doi = "https://doi.org/test"
+    help_text = "For help, hover the cursor over each parameter."
 
-    header = header_widget(package_name, package_tagline, package_tutorial)
+    header = header_widget(
+        package_name,
+        package_tagline,
+        tutorial_file_name=tutorial_file_name,
+        documentation_path=documentation_path,
+        citation_doi=citation_doi,
+        help_text=help_text,
+    )
 
     qtbot.addWidget(header)
 
     expected_strings_logo = [package_name, "brainglobe.png"]
     expected_strings_docs = [
         package_tagline,
-        package_tutorial,
+        tutorial_file_name,
+        documentation_path,
+        citation_doi,
+        help_text,
         "https://brainglobe.info",
         "https://github.com",
     ]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The `header_widget` currently doesn't support some of the required features for existing brainglobe headers like [cellfinder](https://github.com/brainglobe/cellfinder/blob/main/cellfinder/napari/utils.py) and [brainrender-napari](https://github.com/brainglobe/brainrender-napari/blob/main/brainrender_napari/utils/brainglobe_logo.py)

**What does this PR do?**
This PR adds new features to the `header_widget`:
- Makes tutorial links optional
- Adds option for documentation links
- Adds option for citation doi
- Adds option for help text
- Adds option for github repo name (if not the same as the package name)

## References

For https://github.com/brainglobe/cellfinder/issues/327

## How has this PR been tested?

All tests pass locally.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Relevant docstrings have been updated.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
