### PR TITLE
Remove nrrd IO

### DIFF
--- a/brainglobe_utils/IO/image/load.py
+++ b/brainglobe_utils/IO/image/load.py
@@ -7,7 +7,6 @@ from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Tuple
 
-import nrrd
 import numpy as np
 import tifffile
 from dask import array as da
@@ -50,7 +49,7 @@ def load_any(
     Parameters
     ----------
     src_path : str or pathlib.Path
-        Can be the path of a nifty file, nrrd file, tiff file, tiff files
+        Can be the path of a nifty file, tiff file, tiff files
         folder, or text file containing a list of paths.
 
     x_scaling_factor : float, optional
@@ -136,9 +135,6 @@ def load_any(
             z_scaling_factor,
             anti_aliasing=anti_aliasing,
         )
-    elif src_path.suffix == ".nrrd":
-        logging.debug("Data type is: nrrd")
-        img = load_nrrd(src_path)
     elif src_path.suffix in [".nii", ".nii.gz"]:
         logging.debug("Data type is: NifTI")
         img = load_nii(src_path, as_array=True, as_numpy=as_numpy)
@@ -148,27 +144,6 @@ def load_any(
         )
 
     return img
-
-
-def load_nrrd(src_path):
-    """
-    Load an .nrrd file as a numpy array.
-
-    Parameters
-    ----------
-    src_path : str or pathlib.Path
-        The path of the image to be loaded.
-
-    Returns
-    -------
-    np.ndarray
-        The loaded brain array.
-    """
-    if isinstance(src_path, Path):
-        src_path = str(src_path.resolve())
-
-    stack, _ = nrrd.read(src_path)
-    return stack
 
 
 def load_img_stack(

--- a/brainglobe_utils/IO/image/save.py
+++ b/brainglobe_utils/IO/image/save.py
@@ -1,7 +1,6 @@
 import warnings
 from pathlib import Path
 
-import nrrd
 import numpy as np
 import tifffile
 
@@ -99,24 +98,6 @@ def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):
         tifffile.imwrite(dest_path, img)
 
 
-def to_nrrd(img_volume, dest_path):
-    """
-    Save the image volume (numpy array) as nrrd.
-
-    Parameters
-    ----------
-    img_volume : np.ndarray
-        The image to be saved.
-
-    dest_path : str or pathlib.Path
-        The file path where to save the nrrd image.
-    """
-    if isinstance(dest_path, Path):
-        dest_path = str(dest_path.resolve())
-
-    nrrd.write(dest_path, img_volume)
-
-
 def save_any(img_volume, dest_path):
     """
     Save the image volume (numpy array) to the given file path, using the save
@@ -130,7 +111,7 @@ def save_any(img_volume, dest_path):
     dest_path : str or pathlib.Path
         The file path to save the image to.
         Supports directories (will save a sequence of tiffs), .tif, .tiff,
-        .nrrd and .nii.
+        and .nii.
     """
     dest_path = Path(dest_path)
 
@@ -139,9 +120,6 @@ def save_any(img_volume, dest_path):
 
     elif dest_path.suffix in [".tif", ".tiff"]:
         to_tiff(img_volume, dest_path)
-
-    elif dest_path.suffix == ".nrrd":
-        to_nrrd(img_volume, dest_path)
 
     elif dest_path.suffix == ".nii":
         to_nii(img_volume, dest_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "pandas",
     "psutil",
     "pyarrow",
-    "pynrrd",
     "PyYAML",
     "scikit-image",
     "scipy",
@@ -82,20 +81,6 @@ exclude = ["tests", "docs*"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=brainglobe_utils"
-filterwarnings = [
-    "error",
-    # Emitted by scikit-image on import, see https://github.com/scikit-image/scikit-image/issues/6663
-    # This filter should be removed when scikit-image 0.20 is released
-    "ignore:`np.bool8` is a deprecated alias for `np.bool_`",
-    # Emitted by nptyping, see https://github.com/ramonhagenaars/nptyping/issues/102
-    # for upstream issue
-    "ignore:`np.object0` is a deprecated alias for ``np.object0`",
-    "ignore:`np.int0` is a deprecated alias for `np.intp`",
-    "ignore:`np.uint0` is a deprecated alias for `np.uintp`",
-    "ignore:`np.void0` is a deprecated alias for `np.void`",
-    "ignore:`np.bytes0` is a deprecated alias for `np.bytes_`",
-    "ignore:`np.str0` is a deprecated alias for `np.str_`",
-]
 
 [tool.black]
 target-version = ['py39', 'py310', 'py311']
@@ -114,11 +99,6 @@ select = ["I", "E", "F"]
 
 [tool.mypy]
 ignore_errors = true
-
-# [[tool.mypy.overrides]]
-# module = ["imlib.cells.*"]
-# ignore_errors = false
-# strict = true
 
 [tool.tox]
 legacy_tox_ini = """

--- a/tests/tests/test_IO/test_image_io.py
+++ b/tests/tests/test_IO/test_image_io.py
@@ -277,28 +277,11 @@ def test_nii_read_to_numpy(tmp_path, array_3d):
 
 
 @pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
-def test_nrrd_io(tmp_path, array_3d, use_path):
-    """
-    Test that a 3D image can be written and read correctly as nrrd, using both
-    str and pathlib.Path input.
-    """
-    filename = "test_array.nrrd"
-    if use_path:
-        nrrd_path = tmp_path / filename
-    else:
-        nrrd_path = str(tmp_path / filename)
-
-    save.to_nrrd(array_3d, nrrd_path)
-    assert (load.load_nrrd(nrrd_path) == array_3d).all()
-
-
-@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
 @pytest.mark.parametrize(
     "file_name",
     [
         "test_array.tiff",
         "test_array.tif",
-        "test_array.nrrd",
         "test_array.nii",
         pytest.param("", id="dir of tiffs"),
     ],


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
`pynrrd` seems to be causing a few issues with newer versions of Python (t doesn't seem to have been updated for 2 years). Mostly because it uses nptyping, which itself needs updating. 

However, I don't think we need nrrd IO functionality in brainglobe, because we only deal with tiffs and nii. We may use this functionality in the atlas generation code, but I think if we do, it should be a specific requirement for that script (and not for the whole of brainglobe as it is at the moment). 

Keen to know if this is going to break anything, but I don't think it should. 

**What does this PR do?**
Removes all nrrd IO code. It also removes (what I think is) some outdated error/warning handling. 

## References

N/A

## How has this PR been tested?

Removed nrrd tests, and ran other tests as normal.

## Is this a breaking change?

I don't think so. 

## Does this PR require an update to the documentation?

Yes, the reference to nrrd IO needs to be removed from the website docs. 

## Checklist:

- [x] The code has been tested locally
- [] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
