### PR TITLE
Provide optional dependencies for qt instead of napari

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,16 @@ Shared general purpose tools for the BrainGlobe project, including [citation gen
 pip install brainglobe-utils
 ```
 
-To also include the dependencies required for `napari`, use:
+To also include the dependencies required for Qt widgets, use:
 
 ```bash
-pip install brainglobe-utils[napari]
+pip install brainglobe-utils[qt]
 ```
 
-For development, clone this repository and install the dependencies with one of the following commands:
+For development, clone this repository and install the dependencies with:
 
 ```bash
 pip install -e .[dev]
-pip install -e .[dev,napari]
 ```
 
 ## Citations for BrainGlobe tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ source_code = "https://github.com/brainglobe/brainglobe-utils"
 user_support = "https://github.com/brainglobe/brainglobe-utils/issues"
 
 [project.optional-dependencies]
-napari = ["napari>=0.4.18", "qtpy", "superqt"]
+qt = ["qtpy", "superqt"]
 
 dev = [
     "black",
@@ -60,13 +60,12 @@ dev = [
     "pytest-qt",
     "pytest-mock",
     "pytest",
-    "qtpy",
     "ruff",
     "scikit-image",
     "setuptools_scm",
-    "superqt",
     "tox",
     "pooch",
+    "brainglobe-utils[qt]",
 ]
 
 
@@ -85,7 +84,7 @@ exclude = ["tests", "docs*"]
 addopts = "--cov=brainglobe_utils"
 
 [tool.black]
-target-version = ['py310','py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 skip-string-normalization = false
 line-length = 79
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We were providing optional dependencies via `brainglobe-utils[napari]`. These included `qtpy`, `superqt`, and `napari` itself. I realised that the actual code for the collapsible widgets (located in the `qtpy` folder), doesn't actually make use of `napari`, so that dependency was unnecessary.

**What does this PR do?**
We instead provide `brainglobe-utils[qt]`, which include `qtpy`, `superqt` as before, but NOT `napari`. This should also simplify dependency management in packages that rely on the collapsible widgets.

## References

I realised this while working on [a napari widget for movement](https://github.com/neuroinformatics-unit/movement/pull/218)

## How has this PR been tested?
Existing tests still pass (because napari was actually never even installed in the `dev` environment).

## Is this a breaking change?

In a way, packages that depended on collapsible widgets (`brainglobe-stitch` and `brainglobe-registration`?) need to update their dependencies to `brainglobe-utils[qt]`, and make sure to have a separate `napari` dependency. That's why I'm tagging @IgorTatarnikov as reviewer.

## Does this PR require an update to the documentation?

The README has been updated accordingly.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
