### PR TITLE
improve read_with_dask docs, ignore OME metadata

### DIFF
--- a/brainglobe_utils/IO/image/load.py
+++ b/brainglobe_utils/IO/image/load.py
@@ -768,8 +768,12 @@ def read_z_stack(path):
 def read_with_dask(path):
     """
     Based on https://github.com/tlambert03/napari-ndtiffs
-    :param path:
-    :return:
+
+    Reads a folder of tiffs lazily.
+
+    Note that it will ignore OME metadata, because this causes issues.
+    :param path: folder with tifs.
+    :return: dask array containing stack of tifs
     """
     path = str(path)
     if path.endswith(".txt"):
@@ -780,7 +784,10 @@ def read_with_dask(path):
         filenames = glob.glob(os.path.join(path, "*.tif"))
 
     shape, dtype = get_tiff_meta(filenames[0])
-    lazy_arrays = [lazy_imread(fn) for fn in get_sorted_file_paths(filenames)]
+    lazy_arrays = [
+        lazy_imread(fn, is_ome=False)
+        for fn in get_sorted_file_paths(filenames)
+    ]
     dask_arrays = [
         da.from_delayed(delayed_reader, shape=shape, dtype=dtype)
         for delayed_reader in lazy_arrays

--- a/brainglobe_utils/IO/image/load.py
+++ b/brainglobe_utils/IO/image/load.py
@@ -768,10 +768,12 @@ def read_z_stack(path):
 def read_with_dask(path):
     """
     Based on https://github.com/tlambert03/napari-ndtiffs
-
     Reads a folder of tiffs lazily.
 
-    Note that it will ignore OME metadata, because this causes issues.
+    Note that it will make tifffile.imread ignore OME metadata,
+    because this can cause issues with correct metadata reading.
+    See https://forum.image.sc/t/tifffile-opening-individual-ome-tiff-files-as-single-huge-array-even-when-isolated/77701
+
     :param path: folder with tifs.
     :return: dask array containing stack of tifs
     """

--- a/brainglobe_utils/IO/image/load.py
+++ b/brainglobe_utils/IO/image/load.py
@@ -783,17 +783,12 @@ def read_with_dask(path):
             filenames = [line.rstrip() for line in f.readlines()]
 
     else:
-        filenames_tif = glob.glob(os.path.join(path, "*.tif"))
-        filenames_tiff = glob.glob(os.path.join(path, "*.tiff"))
-        if filenames_tif:
-            filenames = filenames_tif
-        elif filenames_tiff:
-            filenames = filenames_tiff
-        else:
-            raise (
-                ValueError(
-                    f"Folder {path} does not contain any .tif or .tiff files"
-                )
+        filenames = glob.glob(os.path.join(path, "*.tif")) or glob.glob(
+            os.path.join(path, "*.tiff")
+        )
+        if not filenames:
+            raise ValueError(
+                f"Folder {path} does not contain any .tif or .tiff files"
             )
 
     shape, dtype = get_tiff_meta(filenames[0])

--- a/brainglobe_utils/IO/image/load.py
+++ b/brainglobe_utils/IO/image/load.py
@@ -781,7 +781,18 @@ def read_with_dask(path):
             filenames = [line.rstrip() for line in f.readlines()]
 
     else:
-        filenames = glob.glob(os.path.join(path, "*.tif"))
+        filenames_tif = glob.glob(os.path.join(path, "*.tif"))
+        filenames_tiff = glob.glob(os.path.join(path, "*.tiff"))
+        if filenames_tif:
+            filenames = filenames_tif
+        elif filenames_tiff:
+            filenames = filenames_tiff
+        else:
+            raise (
+                ValueError(
+                    f"Folder {path} does not contain any .tif or .tiff files"
+                )
+            )
 
     shape, dtype = get_tiff_meta(filenames[0])
     lazy_arrays = [

--- a/tests/tests/test_IO/test_image_io.py
+++ b/tests/tests/test_IO/test_image_io.py
@@ -80,6 +80,7 @@ def array3d_as_tiff_stack_with_missing_metadata(array_3d, tmp_path):
     return tiff_path
 
 
+@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
 def test_tiff_io(tmp_path, array_3d, use_path):
     """
     Test that a 3D tiff can be written and read correctly, using string

--- a/tests/tests/test_IO/test_image_io.py
+++ b/tests/tests/test_IO/test_image_io.py
@@ -80,7 +80,6 @@ def array3d_as_tiff_stack_with_missing_metadata(array_3d, tmp_path):
     return tiff_path
 
 
-@pytest.mark.parametrize("use_path", [True, False], ids=["Path", "String"])
 def test_tiff_io(tmp_path, array_3d, use_path):
     """
     Test that a 3D tiff can be written and read correctly, using string
@@ -429,3 +428,9 @@ def test_get_size_image_with_missing_metadata(
             str(array3d_as_tiff_stack_with_missing_metadata)
         )
         mock_debug.assert_called_once()
+
+
+def test_read_with_dask_raises(tmp_path):
+    with pytest.raises(ValueError) as e:
+        load.read_with_dask(tmp_path)
+    assert e.match("not contain any .tif or .tiff files")


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

* We currently read certain OME tiff files wrongly in `read_with_dask`, when the metadata for all tiffs is specified in a single tiff's metadata.
* `read_with_dask` lack return value and parameters in docs
* `read_with_dask` ignores `.tiff` files (only finds `.tif` files).

**What does this PR do?**

Ignores the OME metadata, so we can correctly read OME tiff files with dask. Also improvements to docs and ability to read `.tiff` files lazily, and better error handling.

## References

Closes #79 

## How has this PR been tested?

Locally by @niksirbi and me

## Is this a breaking change?

I don't think so.

## Does this PR require an update to the documentation?

Docstrings updated.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)


we would need to make, or download, suitable data to test this on. I tried but only got so far, this will be addressed separately later (`ignore-ome-test` branch in #99 )- so we can use `read_with_dask` for more urgent work. I did add a negative test for a new error that is now being raised.

- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
