### PR TITLE
use log10 for zero padding tiffs

### DIFF
--- a/brainglobe_utils/IO/image/save.py
+++ b/brainglobe_utils/IO/image/save.py
@@ -89,7 +89,7 @@ def to_tiffs(img_volume, path_prefix, path_suffix="", extension=".tif"):
         path_prefix = str(path_prefix.resolve())
 
     z_size = img_volume.shape[0]
-    pad_width = int(round(z_size / 10)) + 1
+    pad_width = int(np.floor(np.log10(z_size)) + 1)
     for i in range(z_size):
         img = img_volume[i, :, :]
         dest_path = (

--- a/tests/tests/test_IO/test_image_io.py
+++ b/tests/tests/test_IO/test_image_io.py
@@ -7,7 +7,7 @@ import psutil
 import pytest
 import tifffile
 
-from brainglobe_utils.IO.image import load, save, utils
+from brainglobe_utils.IO.image import load, save, to_tiffs, utils
 
 
 @pytest.fixture()
@@ -435,3 +435,16 @@ def test_read_with_dask_raises(tmp_path):
     with pytest.raises(ValueError) as e:
         load.read_with_dask(tmp_path)
     assert e.match("not contain any .tif or .tiff files")
+
+
+@pytest.mark.parametrize(
+    "z_size, expected_length",
+    [(10000, 5), (9999, 4), (1, 1)],
+)
+def test_to_tiffs_padwidth(tmp_path, z_size, expected_length):
+    volume = np.ones((z_size, 1, 1))
+    prefix = "test"
+    to_tiffs(volume, tmp_path / prefix)
+    image_path = list(tmp_path.glob("*.tif"))[0]
+    assert str(image_path.stem).split("_")[0] == prefix
+    assert len(str(image_path.stem).split("_")[1]) == expected_length


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Zero-padding width in filenames when saving to tiffs was wrongly calculated.

**What does this PR do?**
Fixes the zero-padding width, and tests it's calculated correctly.

## How has this PR been tested?

New test added.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
