### PR TITLE
Updates shape calculation in `brainreg/transform.py`

### DIFF
--- a/tests/tests/test_brainreg/test_transform.py
+++ b/tests/tests/test_brainreg/test_transform.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
+import brainglobe_space as bgs
 import numpy as np
 import pytest
 from brainglobe_atlasapi import BrainGlobeAtlas
 
 from brainglobe_utils.brainreg.transform import (
     transform_points_from_downsampled_to_atlas_space,
+    transform_points_from_raw_to_downsampled_space,
 )
 
 
@@ -57,3 +59,39 @@ def test_transform_points_from_downsampled_to_atlas_space(
     # all coordinates should be mapped to [1,1,1]*1mm/100um = [10,10,10]
     assert np.all(transformed_points == expected_transformed_points)
     assert points_out_of_bounds == expected_points_out_of_bounds
+
+
+@pytest.mark.parametrize(
+    "source_image_plane," "orientation," "expected_transformed_points,",
+    [
+        (np.ones((100, 100, 100)), "asr", [[10, 5, 5], [12, 6, 6]]),
+        (np.ones((100, 100, 100)), "psr", [[40, 5, 5], [38, 6, 6]]),
+        (Path.home() / "test.tiff", "asr", [[10, 5, 5], [12, 6, 6]]),
+        (Path.home() / "test", "psr", [[40, 5, 5], [38, 6, 6]]),
+        (str(Path.home() / "test.tiff"), "asr", [[10, 5, 5], [12, 6, 6]]),
+        (str(Path.home() / "test"), "psr", [[40, 5, 5], [38, 6, 6]]),
+    ],
+)
+def test_transform_points_from_raw_to_downsampled_space_array(
+    mocker, source_image_plane, orientation, expected_transformed_points
+):
+    if isinstance(source_image_plane, (str, Path)):
+        mocker.patch(
+            "brainglobe_utils.brainreg.transform.get_size_image_from_file_paths",
+            return_value={"z": 100, "y": 100, "x": 100},
+        )
+
+    target_space = bgs.AnatomicalSpace(
+        origin="asr",
+        resolution=(100, 100, 100),
+        shape=(50, 25, 25),
+    )
+
+    raw_points = np.array([[20, 20, 20], [24, 24, 24]])
+    voxel_sizes = [50, 25, 25]
+
+    transformed_points = transform_points_from_raw_to_downsampled_space(
+        raw_points, source_image_plane, orientation, voxel_sizes, target_space
+    )
+
+    assert np.all(transformed_points == expected_transformed_points)

--- a/tests/tests/test_brainreg/test_transform.py
+++ b/tests/tests/test_brainreg/test_transform.py
@@ -64,12 +64,12 @@ def test_transform_points_from_downsampled_to_atlas_space(
 @pytest.mark.parametrize(
     "source_image_plane," "orientation," "expected_transformed_points,",
     [
-        (np.ones((100, 100, 100)), "asr", [[10, 5, 5], [12, 6, 6]]),
-        (np.ones((100, 100, 100)), "psr", [[40, 5, 5], [38, 6, 6]]),
+        (np.ones((200, 100, 100)), "asr", [[10, 5, 5], [12, 6, 6]]),
+        (np.ones((200, 100, 100)), "psr", [[90, 5, 5], [88, 6, 6]]),
         (Path.home() / "test.tiff", "asr", [[10, 5, 5], [12, 6, 6]]),
-        (Path.home() / "test", "psr", [[40, 5, 5], [38, 6, 6]]),
+        (Path.home() / "test", "psr", [[90, 5, 5], [88, 6, 6]]),
         (str(Path.home() / "test.tiff"), "asr", [[10, 5, 5], [12, 6, 6]]),
-        (str(Path.home() / "test"), "psr", [[40, 5, 5], [38, 6, 6]]),
+        (str(Path.home() / "test"), "psr", [[90, 5, 5], [88, 6, 6]]),
     ],
 )
 def test_transform_points_from_raw_to_downsampled_space_array(
@@ -78,7 +78,7 @@ def test_transform_points_from_raw_to_downsampled_space_array(
     if isinstance(source_image_plane, (str, Path)):
         mocker.patch(
             "brainglobe_utils.brainreg.transform.get_size_image_from_file_paths",
-            return_value={"z": 100, "y": 100, "x": 100},
+            return_value={"z": 200, "y": 100, "x": 100},
         )
 
     target_space = bgs.AnatomicalSpace(


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See https://github.com/brainglobe/brainglobe-workflows/issues/137

**What does this PR do?**
Fixes https://github.com/brainglobe/brainglobe-workflows/issues/137

## References
Closes https://github.com/brainglobe/brainglobe-workflows/issues/137

## How has this PR been tested?
Tested by checking the `summary.csv` file generated by a `brainmapper` run from a 2D tiff and 3D tiff. Added tests.

## Is this a breaking change?
Yes, the functionality of `get_anatomical_space_from_image_planes` has changed (now assumes an nd.ndarray is passed with `zyx` axes. Previous functionality can be found in `get_anatomical_space_from_image_path`.

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
