### PR TITLE
Add argsparse function for string input

### DIFF
--- a/brainglobe_utils/general/numerical.py
+++ b/brainglobe_utils/general/numerical.py
@@ -38,7 +38,7 @@ def check_positive_float(value, none_allowed=True):
 
     Parameters
     ----------
-    value : float
+    value : float or None
         Input value.
 
     none_allowed : bool, optional
@@ -46,8 +46,8 @@ def check_positive_float(value, none_allowed=True):
 
     Returns
     -------
-    float
-        Input value, if it's positive.
+    float or None
+        Input value, if it's positive, or None.
 
     Raises
     ------
@@ -55,17 +55,18 @@ def check_positive_float(value, none_allowed=True):
         If input value is invalid.
     """
     ivalue = value
-    if ivalue is not None:
-        ivalue = float(ivalue)
-        if ivalue < 0:
-            raise argparse.ArgumentTypeError(
-                "%s is an invalid positive value" % value
-            )
-    else:
+    if value in (None, "None", "none"):
         if not none_allowed:
-            raise argparse.ArgumentTypeError("%s is an invalid value." % value)
+            raise argparse.ArgumentTypeError(f"{ivalue} is an invalid value.")
+        value = None
+    else:
+        value = float(value)
+        if value < 0:
+            raise argparse.ArgumentTypeError(
+                f"{ivalue} is an invalid positive value"
+            )
 
-    return ivalue
+    return value
 
 
 def check_positive_int(value, none_allowed=True):
@@ -75,7 +76,7 @@ def check_positive_int(value, none_allowed=True):
 
     Parameters
     ----------
-    value : int
+    value : int or None
         Input value.
 
     none_allowed : bool, optional
@@ -83,8 +84,8 @@ def check_positive_int(value, none_allowed=True):
 
     Returns
     -------
-    int
-        Input value, if it's positive.
+    int or None
+        Input value, if it's positive, or None.
 
     Raises
     ------
@@ -92,14 +93,15 @@ def check_positive_int(value, none_allowed=True):
         If input value is invalid.
     """
     ivalue = value
-    if ivalue is not None:
-        ivalue = int(ivalue)
-        if ivalue < 0:
-            raise argparse.ArgumentTypeError(
-                "%s is an invalid positive value" % value
-            )
-    else:
+    if value in (None, "None", "none"):
         if not none_allowed:
-            raise argparse.ArgumentTypeError("%s is an invalid value." % value)
+            raise argparse.ArgumentTypeError(f"{ivalue} is an invalid value.")
+        value = None
+    else:
+        value = int(value)
+        if value < 0:
+            raise argparse.ArgumentTypeError(
+                f"{ivalue} is an invalid positive value"
+            )
 
-    return ivalue
+    return value

--- a/brainglobe_utils/general/string.py
+++ b/brainglobe_utils/general/string.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from typing import Optional
 
@@ -53,3 +54,36 @@ def get_text_lines(
     if return_lines is not None:
         lines = lines[return_lines]
     return lines
+
+
+def check_str(value, none_allowed=True):
+    """
+    Used in argparse to enforce str input.
+
+    Parameters
+    ----------
+    value : str or None
+        Input value.
+
+    none_allowed : bool, optional
+        If False, throw an error for None values.
+
+    Returns
+    -------
+    str or None
+        Input value, if it's str, or None.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If input value is invalid.
+    """
+    ivalue = value
+    if value in (None, "None", "none"):
+        if not none_allowed:
+            raise argparse.ArgumentTypeError(f"{ivalue} is an invalid value.")
+        value = None
+    else:
+        value = str(value)
+
+    return value


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Some argparse parameters in `workflows` accept a string or None. E.g. `torch_device`. This adds support for providing `none` or `None` as input in argparse and converts it to None.

Similarly, it makes the float and int functions also accept them.

If users don't provide those arg, these args will typically default to `None`. But sometimes, you may want to explicitly provide the arg, but set it to None. Or if you programmatically set the arg when calling the command line in a script, you may want to be able to always set the arg. Presently, if you wanted the default None, you'd need to have dropped that parameter.

**What does this PR do?**

Adds the string parser and makes str, int, and float accept none and it's variations as explicit values, instead of only allowing it from the default value.

## References

This is required for https://github.com/brainglobe/brainglobe-workflows/pull/150.

## How has this PR been tested?

I tested it locally.

## Is this a breaking change?

No, it only expands input.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
