### PR TITLE
Fix KeyError when saving artifact-only cell lists

### DIFF
--- a/brainglobe_utils/IO/cells.py
+++ b/brainglobe_utils/IO/cells.py
@@ -444,7 +444,7 @@ def deal_with_artifacts(cell_dict, artifact_keep=True):
         for idx, artifact in enumerate(cell_dict[Cell.ARTIFACT]):
             cell_dict[Cell.ARTIFACT][idx].type = Cell.UNKNOWN
         # Add them to "cell_type = UNKNOWN" list
-        cell_dict[Cell.UNKNOWN].extend(cell_dict[Cell.ARTIFACT])
+        cell_dict.setdefault(Cell.UNKNOWN, []).extend(cell_dict[Cell.ARTIFACT])
     else:
         logging.debug("Removing artifacts")
     del cell_dict[Cell.ARTIFACT]  # outside if, needs to be run regardless

--- a/tests/tests/test_IO/test_cell_io.py
+++ b/tests/tests/test_IO/test_cell_io.py
@@ -262,6 +262,21 @@ def test_cells_to_yml_artifacts_keep(
     check_artifact_save(artifact_keep, written_cells, cells_with_artifacts)
 
 
+@pytest.mark.parametrize("suffix", [".xml", ".yml"])
+def test_save_artifact_only_cells(tmp_path, suffix):
+    """
+    Regression test for https://github.com/brainglobe/brainglobe-utils/issues/127.
+    Saving a list containing only artifact cells should not raise a KeyError.
+    """
+    cells = [Cell((0, 0, 0), Cell.ARTIFACT)]
+    path = tmp_path / f"cells{suffix}"
+    cell_io.save_cells(cells, path)
+    written_cells = cell_io.get_cells(path)
+    # artifact_keep=True by default: artifact converted to UNKNOWN, kept
+    assert len(written_cells) == 1
+    assert written_cells[0].type == Cell.UNKNOWN
+
+
 def assert_cells_df(cells_df, x_vals, y_vals, z_vals, type_vals):
     """
     Check that there are the correct number of cells in the Dataframe, and


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix

**Why is this PR needed?**

Saving a list of cells that contains only `Cell.ARTIFACT` entries raises a `KeyError`. `deal_with_artifacts` assumed `Cell.UNKNOWN` was always present in `cell_dict`, but when no non-artifact cells exist the key is never initialised.

**What does this PR do?**

Uses `setdefault` to initialise `cell_dict[Cell.UNKNOWN]` to an empty list when it is absent before extending it with the converted artifact cells.

## References

Closes #127

## How has this PR been tested?

A regression test (`test_save_artifact_only_cells`) has been added to `tests/tests/test_IO/test_cell_io.py`, parametrized over both `.xml` and `.yml` formats. It reproduces the exact scenario from the issue — saving a list containing a single `Cell.ARTIFACT` — and asserts the cell is written and read back with type `Cell.UNKNOWN`.

## Is this a breaking change?

No. The change only affects the case where `Cell.UNKNOWN` is not yet present in the dict; existing behaviour for mixed-type lists is unchanged.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)