### PR TITLE
Removes specific backend from dev requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dev = [
     "coverage",
     "mypy",
     "pre-commit",
-    "pyqt5",
     "pytest-cov",
     "pytest-qt",
     "pytest-mock",


### PR DESCRIPTION
Removes specific `pyqt5` backend from the optional dev group. `brainglobe-utils[napari]` already requests `napari[all]` which will fetch a default backend with the dev install.